### PR TITLE
i15 - SqsClient now has a single threaded scheduler that refreshes th…

### DIFF
--- a/queuebacca-sqs/src/main/java/io/axonif/queuebacca/sqs/SqsCourier.java
+++ b/queuebacca-sqs/src/main/java/io/axonif/queuebacca/sqs/SqsCourier.java
@@ -16,6 +16,7 @@
 
 package io.axonif.queuebacca.sqs;
 
+import java.time.Duration;
 import java.util.Collection;
 
 import io.axonif.queuebacca.MessageBin;
@@ -52,4 +53,11 @@ public interface SqsCourier {
      * @return the SQS tags
      */
     Collection<SqsTag> getTags();
+
+    /**
+     * Gets the visibility timeout for both the processing and recycling bins.
+     *
+     * @return the visibility timeout as a {@link Duration}
+     */
+    Duration getVisibilityTimeout();
 }


### PR DESCRIPTION
…e visibility timeout of messages that have been received by it.

The behaviour is as follows:
- If the visibility timeout of the queue is less than 2 minutes, it will schedule a refresh in half of the visibility timeout by the visibility timeout (e.g. a visibility timeout of 1 minute will be refreshed every 30 seconds by 1 minute)
- If the visibility timeout is 2 minutes or greater, it will refresh 1 minute prior to the end of the visibility timeout by the visibility timeout (e.g. a visibility timeout of 5 minutes will be refreshed every 4 minutes by 5 minutes)

See #15 for details