### PR TITLE
i32 - "Fallback" message consumers can now be added to subscriptions based on message read count

### DIFF
--- a/queuebacca-core/src/main/java/io/axonif/queuebacca/subscribing/FallbackMessageConsumerFactory.java
+++ b/queuebacca-core/src/main/java/io/axonif/queuebacca/subscribing/FallbackMessageConsumerFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 The Queuebacca Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.axonif.queuebacca.subscribing;
+
+import io.axonif.queuebacca.Message;
+import io.axonif.queuebacca.MessageConsumer;
+
+public interface FallbackMessageConsumerFactory {
+
+    <M extends Message> MessageConsumer<M> create();
+}

--- a/queuebacca-core/src/main/java/io/axonif/queuebacca/subscribing/MessageConsumerSelector.java
+++ b/queuebacca-core/src/main/java/io/axonif/queuebacca/subscribing/MessageConsumerSelector.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 The Queuebacca Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.axonif.queuebacca.subscribing;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collections;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+import io.axonif.queuebacca.Message;
+import io.axonif.queuebacca.MessageConsumer;
+
+class MessageConsumerSelector<M extends Message> {
+
+    private final NavigableMap<Integer, MessageConsumer<M>> consumers;
+
+    private MessageConsumerSelector(NavigableMap<Integer, MessageConsumer<M>> consumers) {
+        this.consumers = consumers;
+    }
+
+    static <M extends Message> Builder<M> builder(MessageConsumer<M> firstMessageConsumer) {
+        requireNonNull(firstMessageConsumer);
+
+        NavigableMap<Integer, MessageConsumer<M>> consumers = new TreeMap<>();
+        consumers.put(0, firstMessageConsumer);
+        return new Builder<>(consumers);
+    }
+
+    static <M extends Message> Builder<M> builder(MessageConsumerSelector<M> existingSelector) {
+        requireNonNull(existingSelector);
+        return new Builder<>(new TreeMap<>(existingSelector.consumers));
+    }
+
+    MessageConsumer<M> select(int readCount) {
+        return consumers.floorEntry(readCount).getValue();
+    }
+
+    int currentReadCountThreshold(int readCount) {
+        return consumers.subMap(0, readCount).keySet().stream()
+                .mapToInt(v -> v)
+                .sum();
+    }
+
+    static class Builder<M extends Message> {
+
+        private final NavigableMap<Integer, MessageConsumer<M>> consumers;
+
+        private Builder(NavigableMap<Integer, MessageConsumer<M>> consumers) {
+            this.consumers = consumers;
+        }
+
+        Builder<M> addNextConsumer(int readCountThreshold, MessageConsumer<M> messageConsumer) {
+            consumers.put(consumers.lastKey() + readCountThreshold, messageConsumer);
+            return this;
+        }
+
+        MessageConsumerSelector<M> build() {
+            return new MessageConsumerSelector<>(Collections.unmodifiableNavigableMap(consumers));
+        }
+    }
+}

--- a/queuebacca-core/src/test/java/io/axonif/queuebacca/IntegrationTest.java
+++ b/queuebacca-core/src/test/java/io/axonif/queuebacca/IntegrationTest.java
@@ -29,6 +29,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 
 import io.axonif.queuebacca.retries.ConstantRetryDelay;
+import io.axonif.queuebacca.subscribing.Subscriber;
+import io.axonif.queuebacca.subscribing.SubscriptionConfiguration;
 
 public class IntegrationTest {
 
@@ -37,8 +39,10 @@ public class IntegrationTest {
 	@Test
 	public void subscribe() throws InterruptedException {
 		MessageBin messageBin = new MessageBin("test");
-		TestClient Client = new TestClient();
-		Subscriber subscriber = new Subscriber(Client, ThreadPoolWorkExecutor::newPooledWorkExecutor, exceptionResolver);
+		TestClient client = new TestClient();
+		Subscriber subscriber = Subscriber.builder(client)
+				.withExceptionResolver(exceptionResolver)
+				.build();
 
 		MessageConsumer<TestMessage> consumer = MessageConsumer.basic(TestMessage::markComplete);
 		SubscriptionConfiguration<TestMessage> configuration = SubscriptionConfiguration.builder(messageBin, consumer)
@@ -51,7 +55,7 @@ public class IntegrationTest {
 				.build();
 		subscriber.subscribe(configuration);
 
-		Publisher publisher = new Publisher(Client, messageBin);
+		Publisher publisher = new Publisher(client, messageBin);
 
 		CountDownLatch countDownLatch = new CountDownLatch(10);
 		Collection<TestMessage> messages = new ArrayList<>();
@@ -69,8 +73,10 @@ public class IntegrationTest {
 	@Test
 	public void subscribe_FailedMessage() throws InterruptedException {
 		MessageBin messageBin = new MessageBin("test");
-		TestClient Client = new TestClient();
-		Subscriber subscriber = new Subscriber(Client, ThreadPoolWorkExecutor::newPooledWorkExecutor, exceptionResolver);
+		TestClient client = new TestClient();
+		Subscriber subscriber = Subscriber.builder(client)
+				.withExceptionResolver(exceptionResolver)
+				.build();
 
 		MessageConsumer<TestMessage> consumer = MessageConsumer.basic(TestMessage::markComplete);
 		SubscriptionConfiguration<TestMessage> configuration = SubscriptionConfiguration.builder(messageBin, consumer)
@@ -84,7 +90,7 @@ public class IntegrationTest {
 				.build();
 		subscriber.subscribe(configuration);
 
-		Publisher publisher = new Publisher(Client, messageBin);
+		Publisher publisher = new Publisher(client, messageBin);
 
 		CountDownLatch countDownLatch = new CountDownLatch(10);
 		Map<TestMessage, AtomicInteger> messageCounters = new ConcurrentHashMap<>();
@@ -110,7 +116,7 @@ public class IntegrationTest {
 		}
 	}
 
-	private class TestMessage implements Message {
+	private static class TestMessage implements Message {
 
 		private final Runnable onComplete;
 

--- a/queuebacca-sqs/src/main/java/io/axonif/queuebacca/sqs/SqsCourier.java
+++ b/queuebacca-sqs/src/main/java/io/axonif/queuebacca/sqs/SqsCourier.java
@@ -34,18 +34,11 @@ public interface SqsCourier {
     String getName();
 
     /**
-     * Gets the {@link MessageBin} representing the processing bin for this {@link SqsCourier}.
+     * Gets the {@link MessageBin} for this {@link SqsCourier}.
      *
-     * @return the processing bin
+     * @return the message bin
      */
-    MessageBin getProcessingBin();
-
-    /**
-     * Gets the {@link MessageBin} representing the recycling bin for this {@link SqsCourier}.
-     *
-     * @return the recycling bin
-     */
-    MessageBin getRecyclingBin();
+    MessageBin getMessageBin();
 
     /**
      * Gets a collection of {@link SqsTag SqsTags} related to this {@link SqsCourier}.


### PR DESCRIPTION
The primary goal here was to remove the need to use the dead letter queues to handle the old recycling behaviour. I also removed the concept of a recycling and processing (something I've been wanting to do since the initial version way back when it was all part of Via).

I think what I'd like to see long term is just removing the functionality altogether, particularly because we can handle this sort of recycling behaviour in the consumer itself if we really want to (read counts, message responses). Then build something else that could potentially be used for this but is more along the lines of a workflow manager (see #6).

See #32 for more details.